### PR TITLE
Putting MetadataExtractor before ContentExtractor

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -38,9 +38,9 @@ class Configuration {
             '\Goose\Modules\Cleaners\DocumentCleaner',
         ],
         'extractors' => [
+            '\Goose\Modules\Extractors\MetaExtractor',
             '\Goose\Modules\Extractors\ContentExtractor',
             '\Goose\Modules\Extractors\ImageExtractor',
-            '\Goose\Modules\Extractors\MetaExtractor',
             '\Goose\Modules\Extractors\PublishDateExtractor',
         ],
         'formatters' => [


### PR DESCRIPTION
Changed extractor order to have metadata extracted before content, this allows language detection on the article.