### PR TITLE
Added a case to bypass \GuzzleHttp\Exception\RequestException when downloading assets fails.

### DIFF
--- a/src/Images/ImageUtils.php
+++ b/src/Images/ImageUtils.php
@@ -12,15 +12,13 @@ use GuzzleHttp\Client as GuzzleClient;
  * @package Goose\Images
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  */
-class ImageUtils
-{
+class ImageUtils {
     /**
      * @param string $filePath
      *
      * @return object
      */
-    public static function getImageDimensions($filePath)
-    {
+    public static function getImageDimensions($filePath) {
         list($width, $height, $type) = getimagesize($filePath);
 
         return (object)[
@@ -40,8 +38,7 @@ class ImageUtils
      *
      * @return LocallyStoredImage[]
      */
-    public static function storeImagesToLocalFile($imageSrcs, $returnAll, Configuration $config)
-    {
+    public static function storeImagesToLocalFile($imageSrcs, $returnAll, Configuration $config) {
         $localImages = self::handleEntity($imageSrcs, $returnAll, $config);
 
         if (empty($localImages)) {
@@ -71,8 +68,7 @@ class ImageUtils
      *
      * @return string
      */
-    private static function getFileExtensionName($imageDetails)
-    {
+    private static function getFileExtensionName($imageDetails) {
         $extensions = [
             'image/gif' => '.gif',
             'image/jpeg' => '.jpg',
@@ -93,8 +89,7 @@ class ImageUtils
      *
      * @return object[]|null
      */
-    private static function handleEntity($imageSrcs, $returnAll, $config)
-    {
+    private static function handleEntity($imageSrcs, $returnAll, $config) {
         $guzzle = new GuzzleClient();
 
         $requests = [];

--- a/src/Images/ImageUtils.php
+++ b/src/Images/ImageUtils.php
@@ -12,13 +12,15 @@ use GuzzleHttp\Client as GuzzleClient;
  * @package Goose\Images
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  */
-class ImageUtils {
+class ImageUtils
+{
     /**
      * @param string $filePath
      *
      * @return object
      */
-    public static function getImageDimensions($filePath) {
+    public static function getImageDimensions($filePath)
+    {
         list($width, $height, $type) = getimagesize($filePath);
 
         return (object)[
@@ -38,7 +40,8 @@ class ImageUtils {
      *
      * @return LocallyStoredImage[]
      */
-    public static function storeImagesToLocalFile($imageSrcs, $returnAll, Configuration $config) {
+    public static function storeImagesToLocalFile($imageSrcs, $returnAll, Configuration $config)
+    {
         $localImages = self::handleEntity($imageSrcs, $returnAll, $config);
 
         if (empty($localImages)) {
@@ -68,7 +71,8 @@ class ImageUtils {
      *
      * @return string
      */
-    private static function getFileExtensionName($imageDetails) {
+    private static function getFileExtensionName($imageDetails)
+    {
         $extensions = [
             'image/gif' => '.gif',
             'image/jpeg' => '.jpg',
@@ -89,7 +93,8 @@ class ImageUtils {
      *
      * @return object[]|null
      */
-    private static function handleEntity($imageSrcs, $returnAll, $config) {
+    private static function handleEntity($imageSrcs, $returnAll, $config)
+    {
         $guzzle = new GuzzleClient();
 
         $requests = [];
@@ -111,6 +116,13 @@ class ImageUtils {
         foreach ($batchResults as $batchResult) {
             /** @todo Handle failures gracefully */
             if ($batchResult instanceof \GuzzleHttp\Exception\ClientException) {
+                if ($returnAll) {
+                    $results[] = (object)[
+                        'url' => $batchResult->getResponse()->getEffectiveUrl(),
+                        'file' => null,
+                    ];
+                }
+            } elseif ($batchResult instanceof \GuzzleHttp\Exception\RequestException) {
                 if ($returnAll) {
                     $results[] = (object)[
                         'url' => $batchResult->getResponse()->getEffectiveUrl(),


### PR DESCRIPTION
Hi, this fix doesn't provide a good failure handling, but bypasses the case raising an undefined getStatusCode method when $batchResult is an instance of  \GuzzleHttp\Exception\RequestException.

It often happens to me when fetching an image has to follow a lot of redirects.