### PR TITLE
Added additional publish date search functions to PublishDateExtractor()

### DIFF
--- a/src/Modules/Extractors/MetaExtractor.php
+++ b/src/Modules/Extractors/MetaExtractor.php
@@ -21,7 +21,7 @@ class MetaExtractor extends AbstractModule implements ModuleInterface {
 
     /** @var string[] */
     protected static $SPLITTER_CHARS = [
-        '|', '-', '»', ':',
+        '|', '-', 'ï¿½', ':',
     ];
 
     /** @var string */
@@ -79,6 +79,17 @@ class MetaExtractor extends AbstractModule implements ModuleInterface {
             $property = explode(':', $node->attr('property'));
 
             $results[$property[1]] = $node->attr('content');
+        }
+
+        // Additionally retrieve type values based on provided og:type (http://ogp.me/#types)
+        if (isset($results['type'])) {
+            $nodes = $this->article()->getDoc()->find('meta[property^="' . $results['type'] .':"]');
+
+            foreach ($nodes as $node) {
+                $property = explode(':', $node->attr('property'));
+
+                $results[$property[1]] = $node->attr('content');
+            }
         }
 
         return $results;

--- a/src/Modules/Extractors/MetaExtractor.php
+++ b/src/Modules/Extractors/MetaExtractor.php
@@ -21,7 +21,7 @@ class MetaExtractor extends AbstractModule implements ModuleInterface {
 
     /** @var string[] */
     protected static $SPLITTER_CHARS = [
-        '|', '-', '�', ':',
+        '|', '-', '»', ':',
     ];
 
     /** @var string */

--- a/src/Modules/Extractors/PublishDateExtractor.php
+++ b/src/Modules/Extractors/PublishDateExtractor.php
@@ -20,12 +20,32 @@ class PublishDateExtractor extends AbstractModule implements ModuleInterface {
     /**
      * @param Article $article
      *
-     * @return DateTime
+     * @return \DateTime
      */
     public function run(Article $article) {
         $this->article($article);
 
-        $article->setPublishDate($this->getDateFromURL());
+        $dt = null;
+
+        $dt = $this->getDateFromSchemaOrg();
+
+        if (is_null($dt)) {
+            $dt = $this->getDateFromOpenGraph();
+        }
+
+        if (is_null($dt)) {
+            $dt = $this->getDateFromURL();
+        }
+
+        if (is_null($dt)) {
+            $dt = $this->getDateFromDublinCore();
+        }
+
+        if (is_null($dt)) {
+            $dt = $this->getDateFromParsely();
+        }
+
+        $article->setPublishDate($dt);
     }
 
     private function getDateFromURL() {

--- a/src/Modules/Extractors/PublishDateExtractor.php
+++ b/src/Modules/Extractors/PublishDateExtractor.php
@@ -223,10 +223,12 @@ class PublishDateExtractor extends AbstractModule implements ModuleInterface {
         /* @var $node Element */
         foreach ($nodes as $node) {
             try {
-                $json = json_decode($node->text());
-                if (isset($json->pub_date)) {
-                    $dt = new \DateTime($json->pub_date);
-                    break;
+                if ($node->hasAttribute('content')) {
+                    $json = json_decode($node->getAttribute('content'));
+                    if (isset($json->pub_date)) {
+                        $dt = new \DateTime($json->pub_date);
+                        break;
+                    }
                 }
             }
             catch (\Exception $e) {

--- a/src/Modules/Extractors/PublishDateExtractor.php
+++ b/src/Modules/Extractors/PublishDateExtractor.php
@@ -133,4 +133,32 @@ class PublishDateExtractor extends AbstractModule implements ModuleInterface {
 
         return $dt;
     }
+
+    /**
+     * Check for and determine dates based on OpenGraph standards.
+     *
+     * @return \DateTime|null
+     *
+     * @see http://ogp.me/
+     * @see http://ogp.me/#type_article
+     */
+    private function getDateFromOpenGraph() {
+        $dt = null;
+
+        $og_data = $this->article()->getOpenGraph();
+
+        try {
+            if (isset($og_data['published_time'])) {
+                $dt = new \DateTime($og_data['published_time']);
+            }
+            if (is_null($dt) && isset($og_data['pubdate'])) {
+                $dt = new \DateTime($og_data['pubdate']);
+            }
+        }
+        catch (\Exception $e) {
+            // Do nothing here in case the node has unrecognizable date information.
+        }
+
+        return $dt;
+    }
 }

--- a/src/Modules/Extractors/PublishDateExtractor.php
+++ b/src/Modules/Extractors/PublishDateExtractor.php
@@ -101,4 +101,36 @@ class PublishDateExtractor extends AbstractModule implements ModuleInterface {
 
         return $dt;
     }
+
+    /**
+     * Check for and determine dates based on Dublin Core standards.
+     *
+     * @return \DateTime|null
+     *
+     * @see http://dublincore.org/documents/dcmi-terms/#elements-date
+     * @see http://dublincore.org/documents/2000/07/16/usageguide/qualified-html.shtml
+     */
+    private function getDateFromDublinCore() {
+        $dt = null;
+        $nodes = $this->article()->getRawDoc()->find('*[name="dc.date"], *[name="dc.date.issued"], *[name="DC.date.issued"]');
+
+        /* @var $node Element */
+        foreach ($nodes as $node) {
+            try {
+                if ($node->hasAttribute('content')) {
+                    $dt = new \DateTime($node->getAttribute('content'));
+                    break;
+                }
+            }
+            catch (\Exception $e) {
+                // Do nothing here in case the node has unrecognizable date information.
+            }
+        }
+
+        if (!is_null($dt)) {
+            return $dt;
+        }
+
+        return $dt;
+    }
 }

--- a/src/Modules/Extractors/PublishDateExtractor.php
+++ b/src/Modules/Extractors/PublishDateExtractor.php
@@ -218,8 +218,21 @@ class PublishDateExtractor extends AbstractModule implements ModuleInterface {
         }
 
         // parsely-page
+        $nodes = $this->article()->getRawDoc()->find('meta[name="parsely-page"]');
 
-        /* @todo https://www.parsely.com/help/integration/ppage/ */
+        /* @var $node Element */
+        foreach ($nodes as $node) {
+            try {
+                $json = json_decode($node->text());
+                if (isset($json->pub_date)) {
+                    $dt = new \DateTime($json->pub_date);
+                    break;
+                }
+            }
+            catch (\Exception $e) {
+                // Do nothing here in case the node has unrecognizable date information.
+            }
+        }
 
         return $dt;
     }

--- a/tests/Modules/Extractors/PublishDateExtractorTest.php
+++ b/tests/Modules/Extractors/PublishDateExtractorTest.php
@@ -35,4 +35,55 @@ class PublishDateExtractorTest extends \PHPUnit_Framework_TestCase
             [null, 'http://example.org/folder/2014-03/26/hello-world', 'Date format: Invalid #2'],
         ];
     }
+
+    /**
+     * @dataProvider getDateFromSchemaOrgProvider
+     */
+    public function testGetDateFromSchemaOrg($expected, $document, $message)
+    {
+        $article = $this->generate($document);
+        $this->setArticle($article);
+        $article->setRawDoc($document);
+
+        $this->assertEquals(
+            $expected,
+            $this->call('getDateFromSchemaOrg'),
+            $message
+        );
+    }
+
+    public function getDateFromSchemaOrgProvider() {
+        return [
+            [
+                new \DateTime('2016-05-31T22:52:11Z'),
+                $this->document('<html><head><title>Example Article</title><meta itemprop="datePublished" content="2016-05-31T22:52:11Z"></head></html>'),
+                'Valid date with tag: <meta> and attribute: "content"'
+            ],
+            [
+                new \DateTime('2016-05-31T22:52:11Z'),
+                $this->document('<html><head><title>Example Article</title><meta itemprop="datePublished" datetime="2016-05-31T22:52:11Z"></head></html>'),
+                'Valid date with tag: <meta> and attribute: "datetime"'
+            ],
+            [
+                new \DateTime('2016-05-31T22:52:11Z'),
+                $this->document('<html><head><title>Example Article</title></head><body><article>Content<time itemprop="datePublished" datetime="2016-05-31T22:52:11Z"></article></body></html>'),
+                'Valid date with tag: <time> and attribute: "datetime"'
+            ],
+            [
+                new \DateTime('2016-05-31'),
+                $this->document('<html><head><title>Example Article</title><script type="application/ld+json">{"@context":"http://schema.org","@type":"Article","author":"John Smith","datePublished":"2016-05-31"}</script></head></html>'),
+                'Valid date with JSON-LD and attribute: "datePublished"'
+            ],
+            [
+                null,
+                $this->document('<html><head><title>Example Article</title></head></html>'),
+                'No date provided.'
+            ],
+            [
+                null,
+                $this->document('<html><head><title>Example Article</title><meta itemprop="datePublished" datetime="two days ago"></head></html>'),
+                'Invalid date format provided.'
+            ]
+        ];
+    }
 }

--- a/tests/Modules/Extractors/PublishDateExtractorTest.php
+++ b/tests/Modules/Extractors/PublishDateExtractorTest.php
@@ -174,4 +174,51 @@ class PublishDateExtractorTest extends \PHPUnit_Framework_TestCase
             ]
         ];
     }
+
+
+    /**
+     * @dataProvider getDateFromParselyProvider
+     */
+    public function testGetDateFromParsely($expected, $document, $message)
+    {
+        $article = $this->generate($document);
+        $this->setArticle($article);
+        $article->setRawDoc($document);
+
+        $this->assertEquals(
+            $expected,
+            $this->call('getDateFromParsely'),
+            $message
+        );
+    }
+
+    public function getDateFromParselyProvider() {
+        return [
+            [
+                new \DateTime('2016-05-31T22:52:11Z'),
+                $this->document('<html><head><title>Example Article</title><script type="application/ld+json">{"@context":"http://schema.org","@type":"NewsArticle","creator":["John Smith"],"dateCreated":"2016-05-31T22:52:11Z"}</script></head></html>'),
+                'Valid date with JSON-LD and attribute: "datePublished"'
+            ],
+            [
+                new \DateTime('2016-05-31T22:52:11Z'),
+                $this->document('<html><head><title>Example Article</title><meta name="parsely-pub-date" content="2016-05-31T22:52:11Z"></head></html>'),
+                'Valid date with tag: <meta> and name: "parsely-pub-date"'
+            ],
+            [
+                new \DateTime('2016-05-31T22:52:11Z'),
+                $this->document('<html><head><title>Example Article</title><meta name="parsely-page" content=\'{"title": "Example Article","pub_date": "2016-05-31T22:52:11Z"}\'></head></html>'),
+                'Valid date with tag: <meta>, name: "parsely-page", attribute "content" and JSON parameter "pub_date"'
+            ],
+            [
+                null,
+                $this->document('<html><head><title>Example Article</title></head></html>'),
+                'No date provided'
+            ],
+            [
+                null,
+                $this->document('<html><head><title>Example Article</title><meta name="parsely-pub-date" content="last"></head></html>'),
+                'Invalid date provided'
+            ],
+        ];
+    }
 }

--- a/tests/Modules/Extractors/PublishDateExtractorTest.php
+++ b/tests/Modules/Extractors/PublishDateExtractorTest.php
@@ -86,4 +86,50 @@ class PublishDateExtractorTest extends \PHPUnit_Framework_TestCase
             ]
         ];
     }
+
+    /**
+     * @dataProvider getDateFromDublinCoreProvider
+     */
+    public function testGetDateFromDublinCore($expected, $document, $message)
+    {
+        $article = $this->generate($document);
+        $this->setArticle($article);
+        $article->setRawDoc($document);
+
+        $this->assertEquals(
+            $expected,
+            $this->call('getDateFromDublinCore'),
+            $message
+        );
+    }
+
+    public function getDateFromDublinCoreProvider() {
+        return [
+            [
+                new \DateTime('2016-05-31T22:52:11Z'),
+                $this->document('<html><head><title>Example Article</title><meta name="dc.date" content="2016-05-31T22:52:11Z"></head></html>'),
+                'Valid date with tag: <meta> and name: "dc.date"'
+            ],
+            [
+                new \DateTime('2016-05-31T22:52:11Z'),
+                $this->document('<html><head><title>Example Article</title><meta name="dc.date.issued" content="2016-05-31T22:52:11Z"></head></html>'),
+                'Valid date with tag: <meta> and name: "dc.date.issued"'
+            ],
+            [
+                new \DateTime('2016-05-31T22:52:11Z'),
+                $this->document('<html><head><title>Example Article</title><meta name="DC.date.issued" content="2016-05-31T22:52:11Z"></head></html>'),
+                'Valid date with tag: <meta> and name: "DC.date.issued"'
+            ],
+            [
+                null,
+                $this->document('<html><head><title>Example Article</title></head></html>'),
+                'No date provided.'
+            ],
+            [
+                null,
+                $this->document('<html><head><title>Example Article</title><meta name="DC.date.issued" content="2"</head></html>'),
+                'Invalid date format provided.'
+            ]
+        ];
+    }
 }

--- a/tests/Modules/Extractors/PublishDateExtractorTest.php
+++ b/tests/Modules/Extractors/PublishDateExtractorTest.php
@@ -77,12 +77,12 @@ class PublishDateExtractorTest extends \PHPUnit_Framework_TestCase
             [
                 null,
                 $this->document('<html><head><title>Example Article</title></head></html>'),
-                'No date provided.'
+                'No date provided'
             ],
             [
                 null,
                 $this->document('<html><head><title>Example Article</title><meta itemprop="datePublished" datetime="two days ago"></head></html>'),
-                'Invalid date format provided.'
+                'Invalid date format provided'
             ]
         ];
     }
@@ -123,12 +123,54 @@ class PublishDateExtractorTest extends \PHPUnit_Framework_TestCase
             [
                 null,
                 $this->document('<html><head><title>Example Article</title></head></html>'),
-                'No date provided.'
+                'No date provided'
             ],
             [
                 null,
                 $this->document('<html><head><title>Example Article</title><meta name="DC.date.issued" content="2"</head></html>'),
-                'Invalid date format provided.'
+                'Invalid date format provided'
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider getDateFromOpenGraphProvider
+     */
+    public function testGetDateFromOpenGraph($expected, $article, $message)
+    {
+        $this->setArticle($article);
+
+        $this->assertEquals(
+            $expected,
+            $this->call('getDateFromOpenGraph'),
+            $message
+        );
+    }
+
+    public function getDateFromOpenGraphProvider() {
+        $pubdate_article = $this->generate('<html><head><title>Example Article</title></html>');
+        $pubdate_article->setOpenGraph(['pubdate' => '2016-05-31T22:52:11Z']);
+
+        $published_time_article = $this->generate('<html><head><title>Example Article</title></html>');
+        $published_time_article->setOpenGraph(['published_time' => '2016-05-31T22:52:11Z']);
+
+        $no_og_article = $this->generate('<html><head><title>Example Article</title></html>');
+
+        return [
+            [
+                new \DateTime('2016-05-31T22:52:11Z'),
+                $pubdate_article,
+                'Valid date with og:pubdate'
+            ],
+            [
+                new \DateTime('2016-05-31T22:52:11Z'),
+                $published_time_article,
+                'Valid date with og:article and article:published_time'
+            ],
+            [
+                null,
+                $no_og_article,
+                'No date provided'
             ]
         ];
     }


### PR DESCRIPTION
Per #32, added four new functions to PublishDateExtractor() to search for article publish date based on data from Schema.org, OpenGraph, Dublin Core and Parsely.

Also made a small addition to MetaExtractor->getOpenGraph() to retrieve special type-specific nodes for OpenGraph content.