### PR TITLE
Fixed the invalid argument supplied

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -27,7 +27,7 @@ class Client {
      */
     public function __call($name, $arguments) {
         if (method_exists($this->config, $name)) {
-            return call_user_func_array(array($this->config, $name), $name);
+            return call_user_func_array(array($this->config, $name), $arguments);
         }
 
         return null;


### PR DESCRIPTION
This fixed the invalid argument supplied to `call_user_func_array` which was previously throwing `call_user_func_array() expects parameter 2 to be array, string given`.