### PR TITLE
Empty language metadata should not rewrite configuration language

### DIFF
--- a/src/Modules/Extractors/MetaExtractor.php
+++ b/src/Modules/Extractors/MetaExtractor.php
@@ -34,8 +34,7 @@ class MetaExtractor extends AbstractModule implements ModuleInterface {
         $article->setMetaDescription($this->getMetaDescription());
         $article->setMetaKeywords($this->getMetaKeywords());
         $article->setCanonicalLink($this->getCanonicalLink());
-
-        $article->setLanguage($this->getMetaLanguage());
+        $article->setLanguage($this->getMetaLanguage() ?: $this->config()->get('language'));
 
         $this->config()->set('language', $article->getLanguage());
     }

--- a/tests/Modules/Extractors/MetaExtractorTest.php
+++ b/tests/Modules/Extractors/MetaExtractorTest.php
@@ -3,6 +3,8 @@
 namespace Goose\Tests\Modules\Extractors;
 
 use Goose\Article;
+use Goose\Configuration;
+use Goose\Modules\Extractors\MetaExtractor;
 
 class MetaExtractorTest extends \PHPUnit_Framework_TestCase
 {
@@ -26,6 +28,32 @@ class MetaExtractorTest extends \PHPUnit_Framework_TestCase
             $expected,
             $this->call('getTitle'),
             $message
+        );
+    }
+
+    public function testEmptyMetaLanguageShouldNotRewriteConfiguredValue()
+    {
+        $article = $this->generate('<html><head><title>Ut venenatis rutrum ex, eu feugiat dolor</title></head></html>');
+        $metaExtractor = new MetaExtractor(new Configuration([
+            'language' => 'zh'
+        ]));
+        $metaExtractor->run($article);
+        $this->assertSame(
+            'zh',
+            $metaExtractor->config()->get('language')
+        );
+    }
+
+    public function testMetaLanguageShouldRewriteConfiguredValue()
+    {
+        $article = $this->generate('<html><head><title>Ut venenatis rutrum ex, eu feugiat dolor</title><meta name="lang" content="ru" /></head></html>');
+        $metaExtractor = new MetaExtractor(new Configuration([
+            'language' => 'zh'
+        ]));
+        $metaExtractor->run($article);
+        $this->assertSame(
+            'ru',
+            $metaExtractor->config()->get('language')
         );
     }
 


### PR DESCRIPTION
Issues: #24 and #36