### PR TITLE
Update Guzzle RTD URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ $goose = new GooseClient([
     // Fetch all images
     'image_fetch_all' => false,
     // Guzzle configuration - All values are passed directly to Guzzle
-    //   See: http://guzzle.readthedocs.org/en/latest/clients.html#request-options
+    //   See: http://guzzle.readthedocs.io/en/stable/request-options.html
     'browser' => [
         'timeout' => 60,
         'connect_timeout' => 30

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -21,7 +21,7 @@ class Configuration {
         'image_min_height' => 120,
         'image_fetch_best' => true,
         'image_fetch_all' => false,
-        /** @see http://guzzle.readthedocs.org/en/latest/clients.html#request-options */
+        /** @see http://guzzle.readthedocs.io/en/stable/request-options.html */
         'browser' => [
             'timeout' => 60,
             'connect_timeout' => 30,


### PR DESCRIPTION
Old links are 404'ing.