### PR TITLE
avoid exceptions on empty images

### DIFF
--- a/src/Images/ImageUtils.php
+++ b/src/Images/ImageUtils.php
@@ -46,6 +46,10 @@ class ImageUtils {
         $locallyStoredImages = [];
 
         foreach ($localImages as $localImage) {
+            if (empty($localImage->file)) {
+                continue;
+            }
+            
             $imageDetails = self::getImageDimensions($localImage->file);
 
             $locallyStoredImages[] = new LocallyStoredImage([


### PR DESCRIPTION
solves https://hackernoon.com/an-easier-way-to-authenticate-users-in-e2e-tests-230d86071f48 (broken images that can't be downloaded won't propagate to gd methods but are simply omitted)
