### PR TITLE
$depthObj->node needs to be checked if NULL on some conditions

### DIFF
--- a/src/Modules/Extractors/ImageExtractor.php
+++ b/src/Modules/Extractors/ImageExtractor.php
@@ -153,7 +153,7 @@ class ImageExtractor extends AbstractModule implements ModuleInterface {
         } else {
             $depthObj = $this->getDepthLevel($node, $parentDepthLevel, $siblingDepthLevel);
 
-            if ($depthObj) {
+            if ($depthObj && NULL !== $depthObj->node) {
                 return $this->checkForLargeImages($depthObj->node, $depthObj->parentDepth, $depthObj->siblingDepth);
             }
         }


### PR DESCRIPTION
checkForLargeImages() returns an Exception on landing pages pages of some news sites. One example is http://www.spiegel.de/, but there might be others. 