### PR TITLE
Fix error occurring when getimagesize return a null type

### DIFF
--- a/src/Images/ImageUtils.php
+++ b/src/Images/ImageUtils.php
@@ -16,10 +16,14 @@ class ImageUtils {
     /**
      * @param string $filePath
      *
-     * @return object
+     * @return object|null
      */
-    public static function getImageDimensions(string $filePath): \stdClass {
+    public static function getImageDimensions(string $filePath): ?\stdClass {
         list($width, $height, $type) = getimagesize($filePath);
+
+        if ( $type === null ) {
+            return null;
+        }
 
         return (object)[
             'width' => (int)$width,
@@ -51,17 +55,19 @@ class ImageUtils {
             if (empty($localImage->file)) {
                 continue;
             }
-            
+
             $imageDetails = self::getImageDimensions($localImage->file);
 
-            $locallyStoredImages[] = new LocallyStoredImage([
-                'imgSrc' => $localImage->url,
-                'localFileName' => $localImage->file,
-                'bytes' => filesize($localImage->file),
-                'height' => $imageDetails->height,
-                'width' => $imageDetails->width,
-                'fileExtension' => self::getFileExtensionName($imageDetails),
-            ]);
+            if ( $imageDetails !== null ) {
+                $locallyStoredImages[] = new LocallyStoredImage([
+                    'imgSrc' => $localImage->url,
+                    'localFileName' => $localImage->file,
+                    'bytes' => filesize($localImage->file),
+                    'height' => $imageDetails->height,
+                    'width' => $imageDetails->width,
+                    'fileExtension' => self::getFileExtensionName($imageDetails),
+                ]);
+            }
         }
 
         return $locallyStoredImages;


### PR DESCRIPTION
If image src attribute is "https://www.exemple.fr//", getimagesize return null at index 2 ($type)

Then we call image_type_to_mime_type with this null value and it throw this error :
image_type_to_mime_type() expects parameter 1 to be integer, null given

So, I try to fix this error with this PR

Thank you