### PR TITLE
Test improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 phpunit.xml
 vendor
 build
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ jobs:
   fast_finish: true
 
 before_script:
-  - composer install --dev --prefer-source
+  - composer install --prefer-source
 
 script: ./vendor/bin/phpunit --coverage-text

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 <phpunit bootstrap="vendor/autoload.php"
 		 colors="true">
     <testsuites>
-        <testsuite>
+        <testsuite name="php-goose testsuite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>


### PR DESCRIPTION
# Changed log
- Let the `.phpunit.result.cache` file not be under Git version control.
It's generated by `phpunit` unit test executing.
- The `testsuite` tag needs the `name` attribute on `phpunit.xml.dist` file.
The warning message is as follows:

```
PHPUnit 8.5.2 by Sebastian Bergmann and contributors.

  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 5:
  - Element 'testsuite': The attribute 'name' is required but missing.

  Test results may not be as expected.
```

- Removing `--dev` option on `composer install` command, and the deprecated warning message is as follows:

```
You are using the deprecated option "dev". Dev packages are installed by default now.
```