### PR TITLE
Extract article published date from schema.org json with multiple graph types

### DIFF
--- a/src/Modules/Extractors/PublishDateExtractor.php
+++ b/src/Modules/Extractors/PublishDateExtractor.php
@@ -107,6 +107,26 @@ class PublishDateExtractor extends AbstractModule implements ModuleInterface {
         foreach ($nodes as $node) {
             try {
                 $json = json_decode($node->text());
+
+                // Extract the published date from the Schema.org meta data
+                if (isset($json->{'@graph'}) && is_array($json->{'@graph'})) {
+                    foreach ($json->{'@graph'} as $graphData) {
+                        $graphData = (array)$graphData;
+
+                        if (!isset($graphData['datePublished'])) {
+                            continue;
+                        }
+
+                        $date = @$graphData['datePublished'];
+
+                        try {
+                            $dt = new \DateTime($date);
+                        } catch (\Error $ex) {
+                            // Do nothing here in case the node has unrecognizable date information.
+                        }
+                    }
+                }
+
                 if (isset($json->datePublished)) {
                     $date = is_array($json->datePublished)
                         ? array_shift($json->datePublished)

--- a/src/Modules/Extractors/PublishDateExtractor.php
+++ b/src/Modules/Extractors/PublishDateExtractor.php
@@ -112,7 +112,12 @@ class PublishDateExtractor extends AbstractModule implements ModuleInterface {
                         ? array_shift($json->datePublished)
                         : $json->datePublished;
 
-                    $dt = new \DateTime($date);
+                    try {
+                        $dt = new \DateTime($date);
+                    } catch (\Error $ex) {
+                        // Do nothing here in case the node has unrecognizable date information.
+                    }
+
                     break;
                 }
             }

--- a/tests/Modules/Extractors/PublishDateExtractorTest.php
+++ b/tests/Modules/Extractors/PublishDateExtractorTest.php
@@ -80,6 +80,11 @@ class PublishDateExtractorTest extends \PHPUnit\Framework\TestCase
                 'Valid date with JSON-LD and attribute: "datePublished"'
             ],
             [
+                new \DateTime('2016-05-31T22:52:11Z'),
+                $this->document('<html><head><title>Example Article</title><script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","@id":"https://company.com/#organization","name":"Company.com","url":"https://company.com/","sameAs":["https://www.facebook.com/Company-1234","https://www.linkedin.com/company/1234"]},{"@type":"WebSite","@id":"https://company.com/#website","url":"https://company.com/","name":"Company","publisher":{"@id":"https://company.com/#organization"},"potentialAction":{"@type":"SearchAction","target":"https://company.com/?s={search_term_string}","query-input":"required name=search_term_string"}},{"@type":"WebPage","@id":"https://company.com/news/article-1/#webpage","url":"https://company.com/news/article-1/","inLanguage":"en-US","name":"Article 1 | Company","isPartOf":{"@id":"https://company.com/#website"},"datePublished":"2016-05-31T22:52:11+00:00","dateModified":"2016-05-31T22:52:11+00:00"}]}</script></head></html>'),
+                'Valid date with JSON-LD and attribute: "datePublished"'
+            ],
+            [
                 null,
                 $this->document('<html><head><title>Example Article</title></head></html>'),
                 'No date provided'


### PR DESCRIPTION
Hello,

It would be great to have the use case covered as described below.
Thank you in advance!

## Use Case
see article https://tankterminals.com/news/oil-reaches-new-2023-high/

## Issue
Retrieving the `$article->getPublishDate()` returns null, while the html mentions the 'datePublished' property in the Schema.org

## Solution
Adding the use case to the `PublishDateExtractor` class and covered this use case via the 'PublishDateExtractorTest`